### PR TITLE
Add column extractors by type

### DIFF
--- a/src/main/scala/mrpowers/bebe/BebeColumns.scala
+++ b/src/main/scala/mrpowers/bebe/BebeColumns.scala
@@ -59,6 +59,13 @@ object Columns {
   object TimestampColumn {
     def apply(strCol: String): TimestampColumn = TimestampColumn(org.apache.spark.sql.functions.col(strCol))
 
+    def unapply(column: Column): Option[TimestampColumn] = {
+      if (column.expr.dataType == TimestampType)
+        Some(implicitly[FromDf[TimestampColumn]].construct(column))
+      else
+        None
+    }
+
     implicit val timestampFromDf: FromDf[TimestampColumn] = new FromDf[TimestampColumn] {
       override val dataType: DataType = TimestampType
 
@@ -73,6 +80,13 @@ object Columns {
 
   object DateColumn {
     def apply(strCol: String): DateColumn = DateColumn(org.apache.spark.sql.functions.col(strCol))
+
+    def unapply(column: Column): Option[DateColumn] = {
+      if (column.expr.dataType == DateType)
+        Some(implicitly[FromDf[DateColumn]].construct(column))
+      else
+        None
+    }
 
     implicit val integerFromDf: FromDf[DateColumn] = new FromDf[DateColumn] {
       override val dataType: DataType = DateType
@@ -90,6 +104,13 @@ object Columns {
     def apply(strCol: String): IntegerColumn = IntegerColumn(org.apache.spark.sql.functions.col(strCol))
 
     def apply(intCol: Int): IntegerColumn = IntegerColumn(org.apache.spark.sql.functions.lit(intCol))
+
+    def unapply(column: Column): Option[IntegerColumn] = {
+      if (column.expr.dataType == IntegerType)
+        Some(implicitly[FromDf[IntegerColumn]].construct(column))
+      else
+        None
+    }
 
     implicit val integerFromDf: FromDf[IntegerColumn] = new FromDf[IntegerColumn] {
       override val dataType: DataType = IntegerType

--- a/src/main/scala/mrpowers/bebe/Extensions.scala
+++ b/src/main/scala/mrpowers/bebe/Extensions.scala
@@ -1,7 +1,7 @@
 package mrpowers.bebe
 
 import java.sql.{Date, Timestamp}
-import mrpowers.bebe.Columns._
+import mrpowers.bebe.Columns.{ToColumn, _}
 
 import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.functions.{col, lit, typedLit}
@@ -60,6 +60,14 @@ object Extensions {
       */
     def withColumn[T: ToColumn](colName: String)(col: DataFrame => T): DataFrame =
       df.withColumn(colName, implicitly[ToColumn[T]].column(col(df)))
+
+  }
+
+  implicit class BasicCol[T: FromDf: ToColumn](column: T){
+    @inline def from: FromDf[T] = implicitly
+    @inline def to: ToColumn[T] = implicitly
+
+    def as(colName: String): T = from.construct(to.column(column) as colName)
 
   }
 

--- a/src/test/scala/org/apache/spark/sql/ColumnExtractor.scala
+++ b/src/test/scala/org/apache/spark/sql/ColumnExtractor.scala
@@ -1,0 +1,36 @@
+package org.apache.spark.sql
+
+import com.github.mrpowers.spark.fast.tests.ColumnComparer
+import mrpowers.bebe.Columns.{DateColumn, IntegerColumn, TimestampColumn}
+import mrpowers.bebe.Extensions._
+import mrpowers.bebe.SparkSessionTestWrapper
+import org.scalatest.FunSpec
+
+class ColumnExtractor extends FunSpec
+  with SparkSessionTestWrapper
+  with ColumnComparer {
+
+  import spark.implicits._
+
+  describe("column_extractor") {
+
+    def transformDateOrTimestamp(colName: String)(df:DataFrame): IntegerColumn =
+      df(colName) match {
+        case DateColumn(dc) => dc.day_of_month
+        case TimestampColumn(tc) => tc.day_of_month
+        case _ => IntegerColumn(0)
+      }
+
+    it("extracts according to the column") {
+      val df = Seq(
+        ("2020-01-05".d, 5, 0),
+        ("2019-04-13".d, 13, 0)
+      ).toDF("date", "date_expected_month", "integer_expected_month")
+        .withColumn("date_month")(transformDateOrTimestamp("date"))
+        .withColumn("integer_month")(transformDateOrTimestamp("date_expected_month"))
+      assertColumnEquality(df, "date_month", "date_expected_month")
+      assertColumnEquality(df, "integer_month", "integer_expected_month")
+    }
+  }
+
+}


### PR DESCRIPTION
Also added the column common functions implicit class

The extractors will allow something that I find interesting, and right now its _hard_ to do in spark, to diverge the logic by the type of the column, an example will clarify more:

```scala
    def transformDateOrTimestamp(colName: String)(df:DataFrame): IntegerColumn =
      df(colName) match {
        case DateColumn(dc) => dc.day_of_month
        case TimestampColumn(tc) => tc.day_of_month
        case _ => IntegerColumn(0)
      }
```

This combines the power of the pattern matching and custom extractors to describe easily.

The implicit class allows to add common logic to the typed columns, like the method "as" and when the Boolean type is added, type safety comparations of columns 😄 